### PR TITLE
feat: switch to using ngrok3

### DIFF
--- a/flask_ngrok2.py
+++ b/flask_ngrok2.py
@@ -48,7 +48,7 @@ def _run_ngrok(port, auth_token):
         executable = "ngrok"
 
     if auth_token:
-        os.system(f"{executable} authtoken {auth_token}")
+        os.system(f"{executable} config add-authtoken {auth_token}")
 
     ngrok = subprocess.Popen([executable, "http", str(port)])
     atexit.register(ngrok.terminate)
@@ -67,11 +67,11 @@ def _download_ngrok(ngrok_path):
         return
     system = platform.system()
     if system == "Darwin":
-        url = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-darwin-amd64.zip"
+        url = "https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-darwin-arm64.zip"
     elif system == "Windows":
-        url = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-windows-amd64.zip"
+        url = "https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-windows-amd64.zip"
     elif system == "Linux":
-        url = "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip"
+        url = "https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-arm64.tgz"
     else:
         raise Exception(f"{system} is not supported")
     download_path = _download_file(url)


### PR DESCRIPTION
closes #4 

PM from ngrok here. I thought i'd open this based on the suggestions in the issue to change to ngrok 3. This would be even cooler to switch to the new [ngrok-python open source library](https://github.com/ngrok/ngrok-python). 